### PR TITLE
Omit closing PHP tag

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,5 +1,3 @@
 <?php
 
 echo "Hello World!";
-
-?>


### PR DESCRIPTION
It's best practice to omit the closing PHP tag when a file only contains PHP code. This prevents accidental whitespace in the output.

Also see the [PHP documentation on this matter](http://php.net/manual/en/language.basic-syntax.phptags.php)